### PR TITLE
Added rpm packaging specs and makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,7 @@ clean:
 test:
 	make -C tests $@
 
+rpm: 
+	$(MAKE) -C packaging/rpm
+
 -include $(DEPS)

--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -1,0 +1,54 @@
+PACKAGE_NAME?=	rbutils
+
+VERSION?=	$(shell git describe --abbrev=6 --tags HEAD --always | sed 's/-/_/g')
+
+BUILD_NUMBER?= 1
+
+MOCK_CONFIG?=default
+
+RESULT_DIR?=pkgs
+
+all: rpm
+
+
+SOURCES:
+	mkdir -p SOURCES
+
+archive: SOURCES
+	cd ../../ && \
+	git archive --prefix=$(PACKAGE_NAME)-$(VERSION)/ \
+		-o packaging/rpm/SOURCES/$(PACKAGE_NAME)-$(VERSION).tar.gz HEAD
+
+
+build_prepare: archive
+	mkdir -p $(RESULT_DIR)
+	rm -f $(RESULT_DIR)/$(PACKAGE_NAME)*.rpm
+
+
+srpm: build_prepare
+	/usr/bin/mock \
+		-r $(MOCK_CONFIG) \
+		--define "__version $(VERSION)" \
+		--define "__release $(BUILD_NUMBER)" \
+		--resultdir=$(RESULT_DIR) \
+		--buildsrpm \
+		--spec=rbutils.spec \
+		--sources=SOURCES
+	@echo "======= Source RPM now available in $(RESULT_DIR) ======="
+
+rpm: srpm
+	/usr/bin/mock \
+		-r $(MOCK_CONFIG) \
+		--define "__version $(VERSION)"\
+		--define "__release $(BUILD_NUMBER)"\
+		--resultdir=$(RESULT_DIR) \
+		--rebuild $(RESULT_DIR)/$(PACKAGE_NAME)*.src.rpm
+	@echo "======= Binary RPMs now available in $(RESULT_DIR) ======="
+
+clean:
+	rm -rf SOURCES pkgs
+
+distclean: clean
+	rm -f build.log root.log state.log available_pkgs installed_pkgs \
+		*.rpm *.tar.gz
+

--- a/packaging/rpm/rbutils.spec
+++ b/packaging/rpm/rbutils.spec
@@ -1,3 +1,4 @@
+%global libname rbutils
 
 Name:    rbutils
 Version: %{__version}
@@ -7,14 +8,20 @@ License: GNU AGPLv3
 URL: https://github.com/redBorder/rbutils
 Source0: %{name}-%{version}.tar.gz
 
-BuildRequires: gcc librd-devel 
+BuildRequires: gcc >= 4.1 librd-devel 
 
 Summary: Util libraries for redborder C apps
 Group:   Development/Libraries/C and C++
 Requires: librd0
-
-%description
+%description -n %{name}
 %{summary}
+
+%package -n %{name}-devel
+Summary: Development files for %{name}
+Group: Development/Libraries/C and C++
+Requires: %{name} = %{version}-%{release}
+%description -n %{name}-devel
+%{summary}.
 
 %prep
 %setup -qn %{name}-%{version}
@@ -31,15 +38,19 @@ rm -rf %{buildroot}
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
 
-%files
+%files -n %{name}
 %defattr(444,root,root)
-/usr/include/librbutils
 /usr/lib/librbutils.so
 /usr/lib/librbutils.so.0
+
+%files -n %{name}-devel
+%defattr(-,root,root)
+%{_includedir}/librbutils
 /usr/lib/librbutils.a
 
+
 %changelog
-* Wed May 11 2016 Juan J. Prieto <jjprieto@redborder.com> - 1.0.0-1
+* Tue Jun 21 2016 Alberto Rodriguez <arodriguez@redborder.com> - 1.0.0-1
 - first spec version
 
 

--- a/packaging/rpm/rbutils.spec
+++ b/packaging/rpm/rbutils.spec
@@ -1,0 +1,45 @@
+
+Name:    rbutils
+Version: %{__version}
+Release: %{__release}%{?dist}
+
+License: GNU AGPLv3
+URL: https://github.com/redBorder/rbutils
+Source0: %{name}-%{version}.tar.gz
+
+BuildRequires: gcc librd-devel 
+
+Summary: Util libraries for redborder C apps
+Group:   Development/Libraries/C and C++
+Requires: librd0
+
+%description
+%{summary}
+
+%prep
+%setup -qn %{name}-%{version}
+
+%build
+make
+
+%install
+DESTDIR=%{buildroot}/usr make install
+
+%clean
+rm -rf %{buildroot}
+
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
+%files
+%defattr(444,root,root)
+/usr/include/librbutils
+/usr/lib/librbutils.so
+/usr/lib/librbutils.so.0
+/usr/lib/librbutils.a
+
+%changelog
+* Wed May 11 2016 Juan J. Prieto <jjprieto@redborder.com> - 1.0.0-1
+- first spec version
+
+


### PR DESCRIPTION
Added support to generate rpms using mock. It's necessary to tag a release in order to avoid version problems in rpm repo.
